### PR TITLE
Adds Support For GroupMe Attachments

### DIFF
--- a/web_server.py
+++ b/web_server.py
@@ -1,5 +1,6 @@
 """A server-side Flask app to parse POST requests from GroupMe."""
 
+import json
 from json import loads
 from multiprocessing import Process
 
@@ -16,12 +17,35 @@ app = Flask(__name__)
 def index():
     """Method for base route."""
     message_object = loads(request.data)
+    """Prevents the bot from posting its own messages to Discord at all, rather than posting and immediately deleting them."""
+    if message_object['name'] == 'your bots name in groupme':
+        return ''
+    data = {}
+    data['username'] = message_object['name']
+    data['content'] = message_object['text']
+    data['avatar_url'] = message_object['avatar_url']
+    attachment_url = ''
+    attachment_is_image = False
+    attachments = message_object['attachments']
+    if len(attachments) > 0:
+        print(attachments[0].items())
+        if attachments[0]['type'] == 'image':
+            attachment_is_image = True
+           attachment_url = attachments[0]['url']
+        
+    data['embeds'] = []
+    embed = {}
+    if attachment_url:
+        if attached_is_image:
+            embed['image'] = {}
+            embed['image']['url'] = attachment_url
+        else:
+            embed['title'] = message_object['name'],' uploaded a non-image attachment.'
+            embed['url'] = attachment_url
+        data['embeds'].append(embed)
+        
     requests.post(
-        WEBHOOK_URL, data={
-            'username': message_object['name'],
-            'content': message_object['text'],
-            'avatar_url': message_object['avatar_url']
-        }
+        WEBHOOK_URL, data=json.dumps(data), headers={"Content-Type": "application/json"}
     )
     return ''
 


### PR DESCRIPTION
I noticed that while images posted in Discord would be posted to the GroupMe chat, images posted in the GroupMe chat were not being mirrored to Discord. The attachment code in `discord_bot.py` only executed when an image was posted to Discord, so I assumed there just was no support for GroupMe attachments.
This PR alters `web_server.py` so that images posted to the GroupMe chat are seen and relayed to the Discord channel via an embed. Non-image attachments such as videos are posted in the form of a link to the attachment, since Discord can't embed videos. I've seen other bots do it by downloading the video and then manually uploading the video to Discord, but I didn't want to muck with that.
I also noticed that initially, when I posted in Discord the bot would post in GroupMe, then see its own post and post that back in Discord, then delete that post. I added a place for users to put the name of their bot in GroupMe to exclude it, so that it simply doesn't relay the posts that it makes in GroupMe back to Discord.